### PR TITLE
preserve requested URL scheme when redirecting

### DIFF
--- a/lib/sinatra-index.rb
+++ b/lib/sinatra-index.rb
@@ -23,7 +23,13 @@ module Sinatra
               redirect_code = 302
             end
 
-            new_url = URI::HTTP.build(url_options)
+            # build the new URL based on the requested scheme
+            if request.scheme == 'https'
+              new_url = URI::HTTPS.build(url_options)
+            else
+              new_url = URI::HTTP.build(url_options)
+            end
+
             redirect new_url, redirect_code
           end
 

--- a/test/indices_test.rb
+++ b/test/indices_test.rb
@@ -47,6 +47,12 @@ class TestIndices < Test::Unit::TestCase
 
     ENV['RACK_ENV'] = 'development'
   end
+
+  def test_https_scheme
+    get '/qux', {}, {'HTTPS' => 'on'}
+    assert_equal 302, last_response.status
+    assert_equal 'https://', last_response.header['Location'][0..7]
+  end
 end
 
 class TestApp < Sinatra::Base


### PR DESCRIPTION
Until now, no matter what the requested URL scheme was, the newly
generated redirect URL would always be http://. That led to the
following scenario:

GET https://foo.com/bar
-> 301 to http://foo.com/bar/   # useless redirect that breaks SSL chain
-> 301 to https://foo.com/bar/

So now, the requested scheme will be preserved.
